### PR TITLE
fix(consensus): freeze Orchard actions at soft fork

### DIFF
--- a/.github/workflows/emergency-gitian-verify.yml
+++ b/.github/workflows/emergency-gitian-verify.yml
@@ -1,0 +1,113 @@
+name: Emergency Gitian Verify
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - fix/orchard-freeze-softfork
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  native-tests:
+    name: Native build and tests
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            autoconf \
+            automake \
+            bsdmainutils \
+            build-essential \
+            curl \
+            git \
+            libtool \
+            pkg-config \
+            python3 \
+            python3-pip \
+            ruby
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build depends
+        run: make -C depends HOST=x86_64-pc-linux-gnu -j"$(nproc)"
+
+      - name: Configure
+        run: |
+          ./autogen.sh
+          CONFIG_SITE="$PWD/depends/x86_64-pc-linux-gnu/share/config.site" \
+            ./configure --enable-werror
+
+      - name: Build
+        run: make -j"$(nproc)"
+
+      - name: Run make check
+        run: make check
+
+      - name: Run focused Orchard freeze gtests
+        run: |
+          if [ -x src/zcash-gtest ]; then
+            src/zcash-gtest --gtest_filter='Miner.TemporaryOrchardFreezeRequiresTransparentCoinbase:TransactionBuilder.TemporaryOrchardDisablingSoftFork'
+          else
+            echo "src/zcash-gtest not found after build" >&2
+            exit 1
+          fi
+
+  gitian-linux:
+    name: Gitian Linux release build
+    runs-on: ubuntu-22.04
+    timeout-minutes: 720
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            autoconf \
+            automake \
+            build-essential \
+            curl \
+            git \
+            libtool \
+            pkg-config \
+            python3 \
+            ruby
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Show Docker environment
+        run: |
+          docker version
+          docker info
+
+      - name: Build Gitian Linux release
+        run: ./zcutil/build-release.sh --linux -g --tag "$GITHUB_SHA" --jobs "$(nproc)"
+
+      - name: Upload release artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gitian-linux-release
+          path: |
+            release/**
+          if-no-files-found: warn

--- a/.github/workflows/emergency-gitian-verify.yml
+++ b/.github/workflows/emergency-gitian-verify.yml
@@ -82,6 +82,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
+            apt-cacher-ng \
             autoconf \
             automake \
             build-essential \
@@ -91,6 +92,12 @@ jobs:
             pkg-config \
             python3 \
             ruby
+
+      - name: Start apt-cacher-ng
+        run: |
+          sudo sed -i 's/^#\?BindAddress:.*/BindAddress: 0.0.0.0/' /etc/apt-cacher-ng/acng.conf
+          sudo systemctl restart apt-cacher-ng
+          curl --fail --silent --show-error http://127.0.0.1:3142/acng-report.html >/dev/null
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -143,6 +143,7 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_NU6].nActivationHeight = 2;
         consensus.vUpgrades[Consensus::UPGRADE_NU6_1].nProtocolVersion = 170140;
         consensus.vUpgrades[Consensus::UPGRADE_NU6_1].nActivationHeight = 3;
+        consensus.nTemporaryOrchardDisablingSoftForkHeight = 289500;
         consensus.vUpgrades[Consensus::UPGRADE_ZFUTURE].nProtocolVersion = 0x7FFFFFFF;
         consensus.vUpgrades[Consensus::UPGRADE_ZFUTURE].nActivationHeight =
             Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
@@ -585,6 +586,11 @@ public:
         consensus.fPowNoRetargeting = noRetargeting;
     }
 
+    void UpdateTemporaryOrchardDisablingSoftForkHeight(int nHeight)
+    {
+        consensus.nTemporaryOrchardDisablingSoftForkHeight = nHeight;
+    }
+
     void SetRegTestZIP209Enabled() {
         fZIP209Enabled = true;
     }
@@ -699,4 +705,9 @@ void UpdateRegtestPow(
     bool noRetargeting)
 {
     regTestParams.UpdateRegtestPow(nPowMaxAdjustDown, nPowMaxAdjustUp, powLimit, noRetargeting);
+}
+
+void UpdateRegtestTemporaryOrchardDisablingSoftForkHeight(int nHeight)
+{
+    regTestParams.UpdateTemporaryOrchardDisablingSoftForkHeight(nHeight);
 }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -143,7 +143,7 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_NU6].nActivationHeight = 2;
         consensus.vUpgrades[Consensus::UPGRADE_NU6_1].nProtocolVersion = 170140;
         consensus.vUpgrades[Consensus::UPGRADE_NU6_1].nActivationHeight = 3;
-        consensus.nTemporaryOrchardDisablingSoftForkHeight = 289500;
+        consensus.nTemporaryOrchardDisablingSoftForkHeight = 289460;
         consensus.vUpgrades[Consensus::UPGRADE_ZFUTURE].nProtocolVersion = 0x7FFFFFFF;
         consensus.vUpgrades[Consensus::UPGRADE_ZFUTURE].nActivationHeight =
             Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
@@ -310,6 +310,7 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_NU6_1].nProtocolVersion = 170130;
         consensus.vUpgrades[Consensus::UPGRADE_NU6_1].nActivationHeight =
             Consensus::NetworkUpgrade::ALWAYS_ACTIVE;
+        consensus.nTemporaryOrchardDisablingSoftForkHeight = 230314;
         consensus.vUpgrades[Consensus::UPGRADE_ZFUTURE].nProtocolVersion = 0x7FFFFFFF;
         consensus.vUpgrades[Consensus::UPGRADE_ZFUTURE].nActivationHeight =
             Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
@@ -487,6 +488,8 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_NU6_1].nProtocolVersion = 170130;
         consensus.vUpgrades[Consensus::UPGRADE_NU6_1].nActivationHeight =
             Consensus::NetworkUpgrade::ALWAYS_ACTIVE;
+        consensus.nTemporaryOrchardDisablingSoftForkHeight =
+            Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
         consensus.vUpgrades[Consensus::UPGRADE_ZFUTURE].nProtocolVersion = 0x7FFFFFFF;
         consensus.vUpgrades[Consensus::UPGRADE_ZFUTURE].nActivationHeight =
             Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -180,6 +180,11 @@ void UpdateRegtestPow(
     bool noRetargeting);
 
 /**
+ * Allows modifying the regtest temporary Orchard disabling soft fork.
+ */
+void UpdateRegtestTemporaryOrchardDisablingSoftForkHeight(int nHeight);
+
+/**
  * Allows modifying the regtest funding stream parameters.
  */
 void UpdateFundingStreamParameters(Consensus::FundingStreamIndex idx, Consensus::FundingStream fs);

--- a/src/consensus/params.cpp
+++ b/src/consensus/params.cpp
@@ -104,6 +104,12 @@ namespace Consensus {
         return nHeight >= nFutureTimestampSoftForkHeight;
     }
 
+    bool Params::TemporaryOrchardDisablingSoftForkActive(int nHeight) const {
+        return
+            nTemporaryOrchardDisablingSoftForkHeight != Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT &&
+            nHeight >= nTemporaryOrchardDisablingSoftForkHeight;
+    }
+
     int Params::Halving(int nHeight) const {
         // Simplified halving calculation for new emission curve
         // - Blocks 0-120,000: Pre-halving phase (slow start + plateau)

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -330,6 +330,8 @@ struct Params {
 
     bool FutureTimestampSoftForkActive(int nHeight) const;
 
+    bool TemporaryOrchardDisablingSoftForkActive(int nHeight) const;
+
     bool FeatureActive(int nHeight, Consensus::ConsensusFeature feature) const;
 
     bool FeatureRequired(Consensus::ConsensusFeature feature) const;
@@ -488,6 +490,8 @@ struct Params {
      * activation height in chainparams.cpp.
      */
     int nFutureTimestampSoftForkHeight = 2;
+
+    int nTemporaryOrchardDisablingSoftForkHeight = NetworkUpgrade::NO_ACTIVATION_HEIGHT;
 
     /** Proof of work parameters */
     // Juno Cash: Legacy Equihash parameters removed (uses RandomX instead)

--- a/src/gtest/test_miner.cpp
+++ b/src/gtest/test_miner.cpp
@@ -6,6 +6,8 @@
 #include "key.h"
 #include "miner.h"
 #include "util/system.h"
+#include "util/test.h"
+#include "zcash/Address.hpp"
 
 #include <variant>
 
@@ -121,5 +123,28 @@ TEST(Miner, GetMinerAddress) {
         GetMinerAddress(minerAddress);
         EXPECT_FALSE(IsValidMinerAddress(minerAddress));
     }
+}
+
+TEST(Miner, TemporaryOrchardFreezeRequiresTransparentCoinbase) {
+    RegtestActivateNU5();
+    const int freezeHeight = 100;
+    UpdateRegtestTemporaryOrchardDisablingSoftForkHeight(freezeHeight);
+
+    boost::shared_ptr<CReserveScript> coinbaseScript(new CReserveScript());
+    coinbaseScript->reserveScript = CScript() << OP_TRUE;
+    EXPECT_NO_THROW({
+        auto tx = CreateCoinbaseTransaction(Params(), CAmount{0}, coinbaseScript, freezeHeight);
+        EXPECT_TRUE(tx.IsCoinBase());
+        EXPECT_FALSE(tx.GetOrchardBundle().IsPresent());
+    });
+
+    auto saplingSk = libzcash::SaplingSpendingKey::random();
+    MinerAddress shieldedMinerAddress = saplingSk.default_address();
+    EXPECT_THROW(
+        CreateCoinbaseTransaction(Params(), CAmount{0}, shieldedMinerAddress, freezeHeight),
+        std::runtime_error);
+
+    UpdateRegtestTemporaryOrchardDisablingSoftForkHeight(Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    RegtestDeactivateNU5();
 }
 #endif // ENABLE_MINING

--- a/src/gtest/test_transaction_builder.cpp
+++ b/src/gtest/test_transaction_builder.cpp
@@ -274,6 +274,60 @@ TEST(TransactionBuilder, TransparentToOrchard)
     RegtestDeactivateNU5();
 }
 
+TEST(TransactionBuilder, TemporaryOrchardDisablingSoftFork)
+{
+    RegtestActivateNU5();
+    const int freezeHeight = 100;
+    UpdateRegtestTemporaryOrchardDisablingSoftForkHeight(freezeHeight);
+
+    CBasicKeyStore keystore;
+    CKey tsk = AddTestCKeyToKeyStore(keystore);
+    auto scriptPubKey = GetScriptForDestination(tsk.GetPubKey().GetID());
+
+    auto coinType = Params().BIP44CoinType();
+    auto seed = MnemonicSeed::Random(coinType);
+    auto sk = libzcash::OrchardSpendingKey::ForAccount(seed, coinType, 0);
+    auto fvk = sk.ToFullViewingKey();
+    auto ivk = fvk.ToIncomingViewingKey();
+    libzcash::diversifier_index_t j(0);
+    auto recipient = ivk.Address(j);
+
+    auto orchardAnchor = uint256();
+    auto builder = TransactionBuilder(Params(), freezeHeight - 1, orchardAnchor, SaplingMerkleTree::empty_root(), &keystore);
+    builder.AddTransparentInput(COutPoint(uint256S("1234"), 0), scriptPubKey, 5000);
+    builder.AddOrchardOutput(std::nullopt, recipient, 4000, std::nullopt);
+    auto tx = builder.Build().GetTxOrThrow();
+    ASSERT_FALSE(tx.IsCoinBase());
+    ASSERT_TRUE(tx.GetOrchardBundle().IsPresent());
+
+    CValidationState beforeFreezeState;
+    EXPECT_TRUE(ContextualCheckTransaction(tx, beforeFreezeState, Params(), freezeHeight - 1, true));
+    EXPECT_EQ(beforeFreezeState.GetRejectReason(), "");
+
+    CValidationState atFreezeState;
+    EXPECT_FALSE(ContextualCheckTransaction(tx, atFreezeState, Params(), freezeHeight, true));
+    EXPECT_EQ(atFreezeState.GetRejectReason(), "bad-tx-has-orchard-actions");
+
+    auto coinbaseMtx = CreateNewContextualCMutableTransaction(Params().GetConsensus(), freezeHeight, false);
+    coinbaseMtx.vin.resize(1);
+    coinbaseMtx.vin[0].prevout.SetNull();
+    coinbaseMtx.vin[0].scriptSig = CScript() << freezeHeight << OP_0;
+    coinbaseMtx.vout.resize(1);
+    coinbaseMtx.vout[0].scriptPubKey = CScript() << OP_TRUE;
+    coinbaseMtx.vout[0].nValue = 0;
+    coinbaseMtx.nExpiryHeight = freezeHeight;
+    CTransaction coinbaseTx(coinbaseMtx);
+    ASSERT_TRUE(coinbaseTx.IsCoinBase());
+    ASSERT_FALSE(coinbaseTx.GetOrchardBundle().IsPresent());
+
+    CValidationState coinbaseState;
+    EXPECT_TRUE(ContextualCheckTransaction(coinbaseTx, coinbaseState, Params(), freezeHeight, true));
+    EXPECT_EQ(coinbaseState.GetRejectReason(), "");
+
+    UpdateRegtestTemporaryOrchardDisablingSoftForkHeight(Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    RegtestDeactivateNU5();
+}
+
 TEST(TransactionBuilder, ThrowsOnTransparentInputWithoutKeyStore)
 {
     SelectParams(CBaseChainParams::REGTEST);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -446,6 +446,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-limitdescendantcount=<n>", strprintf("Do not accept transactions if any ancestor would have <n> or more in-mempool descendants (default: %u)", DEFAULT_DESCENDANT_LIMIT));
         strUsage += HelpMessageOpt("-limitdescendantsize=<n>", strprintf("Do not accept transactions if any ancestor would have more than <n> kilobytes of in-mempool descendants (default: %u).", DEFAULT_DESCENDANT_SIZE_LIMIT));
         strUsage += HelpMessageOpt("-nuparams=hexBranchId:activationHeight", "Use given activation height for specified network upgrade (regtest-only)");
+        strUsage += HelpMessageOpt("-regtestorcharddisableheight=<n>", "Use given temporary Orchard disabling soft fork height (regtest-only)");
         strUsage += HelpMessageOpt("-nurejectoldversions", strprintf("Reject peers that don't know about the current epoch (regtest-only) (default: %u)", DEFAULT_NU_REJECT_OLD_VERSIONS));
         strUsage += HelpMessageOpt(
                 "-fundingstream=streamId:startHeight:endHeight:comma_delimited_addresses",
@@ -1327,6 +1328,21 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         if (chainparams.NetworkIDString() != "regtest") {
             return InitError("-nurejectoldversions may only be set on regtest.");
         }
+    }
+
+    if (mapArgs.count("-regtestorcharddisableheight")) {
+        if (chainparams.NetworkIDString() != "regtest") {
+            return InitError("Temporary Orchard disabling soft fork height may only be overridden on regtest.");
+        }
+        int nOrchardDisableHeight;
+        if (!ParseInt32(mapArgs["-regtestorcharddisableheight"], &nOrchardDisableHeight)) {
+            return InitError(strprintf("Invalid -regtestorcharddisableheight (%s)", mapArgs["-regtestorcharddisableheight"]));
+        }
+        if (nOrchardDisableHeight < Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT) {
+            return InitError(strprintf("Invalid -regtestorcharddisableheight (%s)", mapArgs["-regtestorcharddisableheight"]));
+        }
+        UpdateRegtestTemporaryOrchardDisablingSoftForkHeight(nOrchardDisableHeight);
+        LogPrintf("Setting temporary Orchard disabling soft fork height to %d\n", nOrchardDisableHeight);
     }
 
     if (!mapMultiArgs["-fundingstream"].empty()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1332,6 +1332,14 @@ bool ContextualCheckTransaction(
         }
     }
 
+    // Soft fork: temporarily require transactions to not contain Orchard actions.
+    if (consensus.TemporaryOrchardDisablingSoftForkActive(nHeight) &&
+        orchard_bundle.IsPresent()) {
+        return state.Invalid(
+            error("ContextualCheckTransaction(): transaction has Orchard actions (temporarily disabled)"),
+            REJECT_INVALID, "bad-tx-has-orchard-actions");
+    }
+
     // Rules that apply to the future epoch
     if (futureActive) {
         switch (tx.nVersionGroupId) {
@@ -4404,6 +4412,10 @@ bool static ConnectTip(CValidationState& state, const CChainParams& chainparams,
 
     for (auto id : ids) {
         uiInterface.NotifyTxExpiration(id);
+    }
+
+    if (chainparams.GetConsensus().nTemporaryOrchardDisablingSoftForkHeight == pindexNew->nHeight + 1) {
+        mempool.removeContainingOrchard();
     }
 
     // Update chainActive & related variables.

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -334,6 +334,11 @@ public:
 
 CMutableTransaction CreateCoinbaseTransaction(const CChainParams& chainparams, CAmount nFees, const MinerAddress& minerAddress, int nHeight)
 {
+        if (chainparams.GetConsensus().TemporaryOrchardDisablingSoftForkActive(nHeight) &&
+            IsShieldedMinerAddress(minerAddress)) {
+            throw std::runtime_error("Shielded miner addresses are disabled by the temporary Orchard soft fork; use a transparent miner address");
+        }
+
         CMutableTransaction mtx = CreateNewContextualCMutableTransaction(
                 chainparams.GetConsensus(), nHeight,
                 !std::holds_alternative<libzcash::OrchardRawAddress>(minerAddress) && nPreferredTxVersion < ZIP225_MIN_TX_VERSION);
@@ -794,6 +799,10 @@ std::optional<MinerAddress> ExtractMinerAddress::operator()(const libzcash::Sapl
     return addr;
 }
 std::optional<MinerAddress> ExtractMinerAddress::operator()(const libzcash::UnifiedAddress &addr) const {
+    if (consensus.TemporaryOrchardDisablingSoftForkActive(height)) {
+        return std::nullopt;
+    }
+
     auto preferred = addr.GetPreferredRecipientAddress(consensus, height);
     if (preferred.has_value()) {
         return examine(preferred.value(), match {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -685,8 +685,10 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
                 // Note that the time to create the coinbase tx here does not add to,
                 // but instead is included in, the 10 second delay, since we're waiting
                 // until an absolute time is reached.
-                if (!cached_next_cb_mtx && IsShieldedMinerAddress(minerAddress)) {
-                    cached_next_cb_height = nHeight + 2;
+                cached_next_cb_height = nHeight + 2;
+                if (!cached_next_cb_mtx &&
+                    IsShieldedMinerAddress(minerAddress) &&
+                    !Params().GetConsensus().TemporaryOrchardDisablingSoftForkActive(cached_next_cb_height)) {
                     cached_next_cb_mtx = CreateCoinbaseTransaction(
                         Params(), CAmount{0}, minerAddress, cached_next_cb_height);
                     next_cb_mtx = cached_next_cb_mtx;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -851,6 +851,24 @@ void CTxMemPool::removeWithoutBranchId(uint32_t nMemPoolBranchId)
     }
 }
 
+void CTxMemPool::removeContainingOrchard()
+{
+    LOCK(cs);
+    std::list<CTransaction> transactionsToRemove;
+
+    for (indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {
+        const CTransaction& tx = it->GetTx();
+        if (tx.GetOrchardBundle().IsPresent()) {
+            transactionsToRemove.push_back(tx);
+        }
+    }
+
+    for (const CTransaction& tx : transactionsToRemove) {
+        std::list<CTransaction> removed;
+        remove(tx, removed, true);
+    }
+}
+
 void CTxMemPool::_clear()
 {
     mapLinks.clear();

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -505,6 +505,7 @@ public:
     void removeForBlock(const std::vector<CTransaction>& vtx, unsigned int nBlockHeight,
                         std::list<CTransaction>& conflicts);
     void removeWithoutBranchId(uint32_t nMemPoolBranchId);
+    void removeContainingOrchard();
     void clear();
     void _clear(); // unlocked
     bool CompareDepthAndScore(const uint256& hasha, const uint256& hashb);

--- a/src/util/test.cpp
+++ b/src/util/test.cpp
@@ -310,6 +310,7 @@ const Consensus::Params& RegtestActivateNU5() {
 }
 
 void RegtestDeactivateNU5() {
+    UpdateRegtestTemporaryOrchardDisablingSoftForkHeight(Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
     UpdateRegtestPow(0, 0, uint256S("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"), true);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_NU5, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_CANOPY, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);


### PR DESCRIPTION
## Summary
- add a temporary Orchard-disabling soft fork at Juno mainnet height 289460 and testnet height 230314
- keep regtest disabled by default, with `-regtestorcharddisableheight=<n>` available for testing
- reject blocks containing transactions with Orchard actions once the freeze is active
- clear Orchard-containing transactions from the mempool at the activation boundary
- require transparent miner coinbase destinations while the freeze is active
- skip precomputing freeze-active shielded coinbases in getblocktemplate longpoll
- add focused coverage for pre-freeze Orchard validity, post-freeze rejection, transparent coinbase validity, and freeze-active miner coinbase behavior

## Verification
- `git diff --check`
- `HOMEBREW_NO_INSTALL_CLEANUP=1 MAKEFLAGS=-j1 ./autogen.sh` attempted locally, but `autoheader` was killed by signal 9 before configure generation completed

## Follow-up
- Port the fixed Orchard circuit / NU6.2-style hard fork in a separate PR and re-enable Orchard actions only at that activation height.